### PR TITLE
Changes site background to an light gray color

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -22,9 +22,10 @@
 }
 /* close commented backslash hack */
 
-/* Main Styles */
+/* Base Styles */
 
 body {
+  background-color: #EFF1F3;
   color: #272727;
   font-family: 'Crimson Text', serif;
 }
@@ -108,10 +109,6 @@ h2 {
 
 .genres-container {
   background-color: #FED766;
-}
-
-.albums-container {
-  background-color: #EFF1F3;
 }
 
 .genres {


### PR DESCRIPTION
Originally we only had the albums on the albums index page with the
gray background. Decided to make that the default background for
every page. Got rid of the CSS that only set that background for
the specific section.

@Salvi6God @scottfirestone @Draganovic  This is good to go!

Closes #34 
