### PR TITLE
Add admin user functionality and dashboard

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,0 +1,4 @@
+class Admin::DashboardsController < Admin::BaseController
+  def show
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,8 @@ class ApplicationController < ActionController::Base
     session.delete(:user_id)
     @current_user = nil
   end
+
+  def current_admin?
+    current_user && current_user.admin?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ActiveRecord::Base
 
   validates :username, presence: true, length: { minimum: 6 }, uniqueness: true
   validates :email, presence: true, format: { with: /@/ }, uniqueness: true
+
+  enum role: ["default", "admin"]
 end

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -1,0 +1,7 @@
+<section class="jumbotron container">
+  <h1>Admin Dashboard</h1>
+</section>
+
+<div class="container">
+  <section class="clearfix">
+    <h3><%= link_to "View Albums", </h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,8 @@ Rails.application.routes.draw do
 
   get "/cart",      to: "carts#index", as: "user_cart"
   get "/:genre",    to: "genres#show", as: "genre"
+
+  namespace :admin do
+    resource :dashboard, only: [:show]
+  end
 end

--- a/db/migrate/20160304014954_add_role_to_users.rb
+++ b/db/migrate/20160304014954_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160302211224) do
+ActiveRecord::Schema.define(version: 20160304014954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,8 +48,9 @@ ActiveRecord::Schema.define(version: 20160302211224) do
     t.string   "username"
     t.string   "email"
     t.string   "password_digest"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.integer  "role",            default: 0
   end
 
   add_foreign_key "albums", "artists"

--- a/spec/features/admin_can_see_admin_dashboard_spec.rb
+++ b/spec/features/admin_can_see_admin_dashboard_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Admin can see admin dashboard" do
+  scenario "they can see the items index with CRUD links" do
+    admin = User.create(username: "administrator",
+                        password: "password",
+                        email: "admin@email.com",
+                        role: 1
+                       )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit admin_dashboard_path
+
+    expect(page).to have_content("Admin Dashboard")
+  end
+end

--- a/spec/features/registered_user_cannot_see_admin_dashboard_spec.rb
+++ b/spec/features/registered_user_cannot_see_admin_dashboard_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Registered user cannot see admin dashboard" do
+  scenario "they get a 404" do
+    user = User.create(username: "scottrick",
+                       password: "password",
+                       email: "email@email.com"
+                      )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit admin_dashboard_path
+
+    expect(page).to have_content("doesn't exist (404)")
+    expect(page).to_not have_content("Admin Dashboard")
+  end
+end

--- a/spec/features/unregistered_user_cannot_visit_admin_dashboard_spec.rb
+++ b/spec/features/unregistered_user_cannot_visit_admin_dashboard_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.feature "Unregistered user cannot visit admin dashboard" do
+  scenario "they get a 404" do
+    visit admin_dashboard_path
+
+    expect(page).to have_content("doesn't exist (404)")
+  end
+end


### PR DESCRIPTION
This change creates an admin dashboard that is only accessible by admins. The dashboard is namespaced under admin.
Users who are unregistered or do not have admin privileges, if they attempt to visit the admin dashboard, receive a 404.

closes #49 
