### PR TITLE
Admin logs in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
 
     if @user && @user.authenticate(params[:session][:password])
       log_in(@user)
-      redirect_to dashboard_path
+      redirect_to @user.authorize_session
     else
       flash[:errors] = "Invalid Credentials"
       render :new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,12 @@ class User < ActiveRecord::Base
   validates :email, presence: true, format: { with: /@/ }, uniqueness: true
 
   enum role: ["default", "admin"]
+
+  def authorize_session
+    if admin?
+      "/admin/dashboard"
+    else
+      "/dashboard"
+    end
+  end
 end

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -4,4 +4,6 @@
 
 <div class="container">
   <section class="clearfix">
-    <h3><%= link_to "View Albums", </h3>
+    <h3><%= link_to "View Albums", albums_path %></h3>
+  </section>
+</div>

--- a/spec/features/admin_can_log_in_spec.rb
+++ b/spec/features/admin_can_log_in_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.feature "Admin can log in" do
+  scenario "they see the admin dashboard" do
+    admin = User.create(username: "administrator",
+                        password: "password",
+                        email: "user@example.com",
+                        role: 1
+                       )
+
+    visit root_path
+    click_on "Login"
+
+    fill_in "Username", with: admin.username
+    fill_in "Password", with: admin.password
+    click_button "Login"
+
+    expect(current_path).to eq(admin_dashboard_path)
+    expect(page).to have_content("Admin Dashboard")
+  end
+end


### PR DESCRIPTION
An admin can now log in through the login page and be directed to the admin dashboard. I added a user method that authorizes that points the user or admin to their respective dashboard. 
This also fixes a previously broken link helper to the albums index found on the admin dashboard.
@julsfelic @Draganovic @Salvi6God 
closes #72 
