### PR TITLE
Admin cannot modify users #51

### DIFF
--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,4 +1,5 @@
 class Admin::DashboardsController < Admin::BaseController
   def show
+    @user = current_user
   end
 end

--- a/app/controllers/admin/infos_controller.rb
+++ b/app/controllers/admin/infos_controller.rb
@@ -1,0 +1,22 @@
+class Admin::InfosController < Admin::BaseController
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    if @user.update(user_params)
+      flash[:message] = "Your info has been updated!"
+      redirect_to admin_dashboard_path
+    else
+      flash.now[:error] = "Invalid Info"
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:username, :email, :password)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = current_user
+    if current_user.admin?
+      redirect_to admin_dashboard_path
+    else
+      @user = current_user
+    end
   end
 
   private

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -2,8 +2,12 @@
   <h1>Admin Dashboard</h1>
 </section>
 
+username: <%= @user.username %>
+email: <%= @user.email %>
+
 <div class="container">
   <section class="clearfix">
+    <h3><%= link_to "Edit Account", edit_admin_info_path %></h3>
     <h3><%= link_to "View Albums", albums_path %></h3>
   </section>
 </div>

--- a/app/views/admin/infos/edit.html.erb
+++ b/app/views/admin/infos/edit.html.erb
@@ -1,0 +1,14 @@
+<h1>Edit Info</h1>
+
+<%= form_for @user, url: admin_info_path do |f| %>
+  <%= f.label :username %>
+  <%= f.text_field :username %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+
+  <%= f.submit "Update Account" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resource :dashboard, only: [:show]
+    resource :info,      only: [:edit, :update]
   end
 end

--- a/spec/features/admin_can_modify_admin_data_spec.rb
+++ b/spec/features/admin_can_modify_admin_data_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "Admin can modify admin info" do
+  scenario "they see the modified info" do
+    admin = User.create(username: "administrator",
+                        password: "password",
+                        email: "user@example.com",
+                        role: 1
+                       )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit admin_dashboard_path
+
+    click_on "Edit Account"
+
+    expect(page).to have_selector("input[value='#{admin.username}']")
+    expect(page).to have_selector("input[value='#{admin.email}']")
+
+    fill_in "Username", with: "New Username"
+    fill_in "Password", with: "new_password"
+    fill_in "Email",    with: "new_email@example.com"
+
+    click_on "Update Account"
+
+    expect(page).to have_content("New Username")
+    expect(page).to_not have_content("administrator")
+
+    expect(page).to have_content("new_email@example.com")
+    expect(page).to_not have_content("user@example.com")
+  end
+end

--- a/spec/features/admin_cannot_edit_other_user_info_spec.rb
+++ b/spec/features/admin_cannot_edit_other_user_info_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Admin cannot edit other user info" do
+  scenario "they get redirected to the admin dashboard" do
+    admin = User.create(username: "administrator",
+                        password: "password",
+                        email: "admin@email.com",
+                        role: 1
+                       )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit dashboard_path
+
+    expect(current_path).to eq(admin_dashboard_path)
+  end
+end


### PR DESCRIPTION
I added a sort of admin user info page for the admin to edit their user info (which appears on the admin dashboard). I also made it so, if the current user is an admin, they can't access the regular/user dashboard but instead are rerouted to the admin dashboard. Let me know what you think!
closes #51  
@julsfelic @Draganovic @Salvi6God 
