### PR TITLE
Fix stripe checkout bug

### DIFF
--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -31,17 +31,17 @@
   </table>
 
   <%= form_tag order_path, id: 'stripeForm' do %>
-    <%= hidden_field_tag "total", @order.total %>
+    <%= hidden_field_tag "total", @order.get_total %>
     <%= hidden_field_tag "stripeToken" %>
     <%= hidden_field_tag "stripeEmail" %>
     <%= hidden_field_tag "stripeAmount" %>
-    <%= button_to "Confirm Order", order_path(:order => {user_id: current_user.id, total: @order.total}), { id: "checkout" } %>
+    <%= button_to "Confirm Order", order_path(:order => {user_id: current_user.id, total: @order.get_total}), { id: "checkout" } %>
   <% end %>
 
   <script src="https://checkout.stripe.com/checkout.js"></script>
   <script>
     $(document).on('ready', function() {
-        var total = <%= @order.total %>
+        var total = <%= @order.get_total %>;
         var handler = StripeCheckout.configure({
           key: "<%= ENV['PUBLISHABLE_KEY'] %>",
           image: '',


### PR DESCRIPTION
Order totaling methods were revised separately from stripe integration. This
fixes the stripe integration to use the current order total methods.

closes #21 

@julsfelic @Draganovic @Salvi6God 
