### PR TITLE
Scopes tests for more accurate test results

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -5,7 +5,7 @@
 
   <h1>Featured Album</h1>
   <h2><%= link_to @featured_album.title, @featured_album %></h2>
-  <h3>by <%= link_to @featured_album.artist.name, @featured_album %></h3>
+  <h3>by <%= link_to @featured_album.artist.name, @featured_album.artist %></h3>
   <%= button_to "Add to cart", carts_path(album_id: @featured_album.id)%>
 </section>
 

--- a/spec/features/guest_adds_items_to_cart_spec.rb
+++ b/spec/features/guest_adds_items_to_cart_spec.rb
@@ -5,7 +5,9 @@ RSpec.feature "Guest adds items to cart" do
     album = FactoryGirl.create(:album)
 
     visit albums_path
-    click_on "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
     click_link "Cart"
 
     expect(current_path).to eq(user_cart_path)
@@ -18,7 +20,9 @@ RSpec.feature "Guest adds items to cart" do
     end
 
     visit albums_path
-    click_on "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
     click_on "Cart"
 
     within(".cart-total") do

--- a/spec/features/guest_can_adjust_quantity_of_an_item_in_the_cart_spec.rb
+++ b/spec/features/guest_can_adjust_quantity_of_an_item_in_the_cart_spec.rb
@@ -4,7 +4,9 @@ RSpec.feature "Guest can adjust quantity of an item in the cart" do
   scenario "they can adjust the quantity by adding" do
     album = FactoryGirl.create(:album)
     visit albums_path
-    click_on "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
     click_link "Cart"
 
     expect(page).to have_css("img[src*='#{album.image_url}']")
@@ -29,7 +31,9 @@ RSpec.feature "Guest can adjust quantity of an item in the cart" do
   scenario "they can adjust the quantity by subtracting" do
     album = FactoryGirl.create(:album)
     visit albums_path
-    click_on "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
     click_link "Cart"
 
     expect(page).to have_css("img[src*='#{album.image_url}']")
@@ -57,7 +61,9 @@ RSpec.feature "Guest can adjust quantity of an item in the cart" do
   scenario "when quantity equals zero album disappears" do
     album = FactoryGirl.create(:album)
     visit albums_path
-    click_on "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
     click_link "Cart"
 
     expect(page).to have_css("img[src*='#{album.image_url}']")

--- a/spec/features/guest_can_checkout_spec.rb
+++ b/spec/features/guest_can_checkout_spec.rb
@@ -6,7 +6,9 @@ RSpec.feature "Guest can checkout" do
     album  = FactoryGirl.create(:album)
 
     visit albums_path
-    click_button "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
 
     visit carts_path
 
@@ -46,7 +48,9 @@ RSpec.feature "Guest can checkout" do
 
     visit albums_path
 
-    click_button "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
 
     expect(page).to have_content("Cart ( 1 )")
 

--- a/spec/features/guest_can_create_account_spec.rb
+++ b/spec/features/guest_can_create_account_spec.rb
@@ -63,7 +63,9 @@ RSpec.feature "Guest can create an account" do
       album = FactoryGirl.create(:album)
 
       visit albums_path
-      click_on "Add to cart"
+      within(".preview") do
+        click_on "Add to cart"
+      end
       click_link "Cart"
 
       expect(page).to have_css("img[src*='#{album.image_url}']")

--- a/spec/features/guest_can_view_total_amount_of_items_in_their_cart_on_the_navigation_spec.rb
+++ b/spec/features/guest_can_view_total_amount_of_items_in_their_cart_on_the_navigation_spec.rb
@@ -6,9 +6,11 @@ RSpec.feature "Guest sees total amount of items in their cart on the navbar" do
 
     visit albums_path
 
-    click_on "Add to cart"
-    click_on "Add to cart"
-    click_on "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+      click_on "Add to cart"
+      click_on "Add to cart"
+    end
 
     within(".site-nav") do
       expect(page).to have_content "3"

--- a/spec/features/guest_removes_item_from_cart_spec.rb
+++ b/spec/features/guest_removes_item_from_cart_spec.rb
@@ -5,7 +5,9 @@ RSpec.feature "Guest removes an item from cart" do
     album = FactoryGirl.create(:album)
 
     visit albums_path
-    click_on "Add to cart"
+    within(".preview") do
+      click_on "Add to cart"
+    end
     click_link "Cart"
 
     expect(page).to have_css("img[src*='#{album.image_url}']")

--- a/spec/features/user_can_view_album_show_page_spec.rb
+++ b/spec/features/user_can_view_album_show_page_spec.rb
@@ -5,7 +5,9 @@ RSpec.feature "User can view album show page" do
     album = FactoryGirl.create(:album)
 
     visit albums_path
-    click_link album.title
+    within(".preview") do
+      click_link album.title
+    end
 
     expect(current_path).to eq(album_path(album))
     expect(page).to have_content(album.title)


### PR DESCRIPTION
A few of the tests were not scoped and were not giving us back consistent
results. Went ahead and scoped them to make sure that the test suite is
clicking on the correct add to cart

Closes #141 

@scottfirestone @Draganovic @Salvi6God 
