### PR TITLE
Refactor formatted price

### DIFF
--- a/app/models/order_album.rb
+++ b/app/models/order_album.rb
@@ -20,10 +20,6 @@ class OrderAlbum < ActiveRecord::Base
     album.price
   end
 
-  def formatted_price
-    number_with_precision(price / 100.0, precision: 2)
-  end
-
   def time_format
     created_at.strftime("%B %d, %Y")
   end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -11,12 +11,12 @@
       </tr>
     </thead>
     <tbody>
-      <% @order.order_albums.each do |order_detail| %>
+      <% @order.order_albums.each do |order_album| %>
         <tr>
-          <td class="ljust"><%= link_to order_detail.album.title, album_path(order_detail.album) %></td>
-          <td>$<%= order_detail.album.formatted_price %></td>
-          <td><%= order_detail.quantity %></td>
-          <td>$<%= order_detail.formatted_sub_total %></td>
+          <td class="ljust"><%= link_to order_album.album.title, album_path(order_album.album) %></td>
+          <td>$<%= order_album.album.formatted_price %></td>
+          <td><%= order_album.quantity %></td>
+          <td>$<%= order_album.formatted_sub_total %></td>
         </tr>
       <% end %>
     </tbody>

--- a/spec/features/user_can_view_specific_past_orders_spec.rb
+++ b/spec/features/user_can_view_specific_past_orders_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Existing user can view past orders" do
       expect(page).to have_link(order_album.title.to_s, album_path(order_album.album))
       expect(page).to have_content("$#{order_album.formatted_sub_total}")
       expect(page).to have_content(order_album.quantity)
-      expect(page).to have_content("$#{order_album.formatted_price}")
+      expect(page).to have_content("$#{order_album.album.formatted_price}")
     end
 
     expect(page).to have_content("$#{order.formatted_total}")


### PR DESCRIPTION
Removed formatted price from order album model, and fixed references so they
point to the order_album.album.

closes #148 

@julsfelic @Salvi6God @Draganovic 
