### PR TITLE
Add expiry date to albums

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,7 +25,7 @@ class OrdersController < ApplicationController
   end
 
   def show
-    @order = Order.find(session[:order_id])
+    @order = Order.find(params[:id])
   end
 
   private

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -23,4 +23,8 @@ class Album < ActiveRecord::Base
   def formatted_price(quantity = 1)
     number_with_precision((price * quantity) / 100.0, precision: 2)
   end
+
+  def expired?
+    Time.now > expiry_date
+  end
 end

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -9,6 +9,10 @@
 
   <footer>
     <h3>$<%= @album.formatted_price %></h3>
-    <%= button_to "Add to cart", carts_path(album_id: @album.id)%>
+    <% if @album.expired? %>
+      <p>Album is no longer available.</p>
+    <% else %>
+      <%= button_to "Add to cart", carts_path(album_id: @album.id)%>
+    <% end %>
   </footer>
 </section>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -30,12 +30,13 @@
     </tfoot>
   </table>
 
-  <%= form_tag order_path, id: 'stripeForm' do %>
+  <%= form_tag @order, id: 'stripeForm' do %>
     <%= hidden_field_tag "total", @order.get_total %>
     <%= hidden_field_tag "stripeToken" %>
     <%= hidden_field_tag "stripeEmail" %>
     <%= hidden_field_tag "stripeAmount" %>
-    <%= button_to "Confirm Order", order_path(:order => {user_id: current_user.id, total: @order.get_total}), { id: "checkout" } %>
+    <%#= button_to "Confirm Order", order_path(@order, :order => {user_id: current_user.id, total: @order.get_total}), { id: "checkout" } %>
+    <%= button_to "Confirm Order", @order, { id: "checkout" } %>
   <% end %>
 
   <script src="https://checkout.stripe.com/checkout.js"></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create]
   resources :carts, only: [:index, :create, :destroy, :update]
-  resource :order, only: [:new, :show, :create]
+  resources :orders, only: [:new, :show, :create, :index]
 
   get "/dashboard", to: "users#show"
 
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
   delete "/logout", to: "sessions#destroy"
 
   get "/cart",      to: "carts#index",  as: "user_cart"
-  get "/orders",    to: "orders#index", as: "orders"
   get "/:genre",    to: "genres#show",  as: "genre"
 
   namespace :admin do

--- a/db/migrate/20160309022345_add_expiry_date_to_albums.rb
+++ b/db/migrate/20160309022345_add_expiry_date_to_albums.rb
@@ -1,0 +1,5 @@
+class AddExpiryDateToAlbums < ActiveRecord::Migration
+  def change
+    add_column :albums, :expiry_date, :datetime, default: (Time.now + 6.months)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160306224550) do
+ActiveRecord::Schema.define(version: 20160309022345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "album_reviews", force: :cascade do |t|
+    t.integer "album_id"
+    t.integer "review_id"
+  end
+
+  add_index "album_reviews", ["album_id"], name: "index_album_reviews_on_album_id", using: :btree
+  add_index "album_reviews", ["review_id"], name: "index_album_reviews_on_review_id", using: :btree
 
   create_table "albums", force: :cascade do |t|
     t.string   "title"
@@ -22,11 +30,12 @@ ActiveRecord::Schema.define(version: 20160306224550) do
     t.string   "image_url"
     t.string   "release_year"
     t.integer  "price"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
     t.integer  "genre_id"
     t.integer  "artist_id"
     t.string   "slug"
+    t.datetime "expiry_date",  default: '2016-09-09 01:55:34'
   end
 
   add_index "albums", ["artist_id"], name: "index_albums_on_artist_id", using: :btree
@@ -72,6 +81,12 @@ ActiveRecord::Schema.define(version: 20160306224550) do
 
   add_index "orders", ["user_id"], name: "index_orders_on_user_id", using: :btree
 
+  create_table "reviews", force: :cascade do |t|
+    t.string   "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string   "username"
     t.string   "email"
@@ -81,6 +96,8 @@ ActiveRecord::Schema.define(version: 20160306224550) do
     t.integer  "role",            default: 0
   end
 
+  add_foreign_key "album_reviews", "albums"
+  add_foreign_key "album_reviews", "reviews"
   add_foreign_key "albums", "artists"
   add_foreign_key "albums", "genres"
   add_foreign_key "order_albums", "albums"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -34,6 +34,7 @@ FactoryGirl.define do
     release_year "1994"
     image_url "http://cdn.pitchfork.com/albums/18689/homepage_large.111d1a3b.jpg"
     price 100
+    expiry_date (Time.now + 6.months)
     sequence(:slug) { |n| "Title #{n}".downcase.gsub(/\s/, "-") }
     artist
   end

--- a/spec/features/guest_can_view_past_orders_spec.rb
+++ b/spec/features/guest_can_view_past_orders_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature "Existing user can view past orders" do
     click_button "Confirm Order"
 
     visit dashboard_path
+
     click_link "Past Orders"
 
     expect(page).to have_content(user.orders.first.id)

--- a/spec/features/user_cannot_purchase_expired_albums_spec.rb
+++ b/spec/features/user_cannot_purchase_expired_albums_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "User cannot purchase expired albums" do
+  scenario "they see that the item is no longer available" do
+    user = FactoryGirl.create(:user)
+    genre = Genre.create(name: "Jazz", slug: "jazz")
+    album = FactoryGirl.create(:album)
+    album.update(genre_id: genre.id)
+    order = user.orders.create(total: 100)
+    order.order_albums.create(album_id: album.id, quantity: 1)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    expect(album.expired?).to eq(false)
+
+    album.update(expiry_date: (Time.now - 7.months))
+
+    visit orders_path
+
+    click_on "Order Number: #{order.id}"
+
+    click_on album.title
+
+    expect(current_path).to eq(album_path(album))
+    expect(page).to have_content("Album is no longer available")
+    expect(page).to_not have_content("Add to cart")
+  end
+end

--- a/spec/models/album_spec.rb
+++ b/spec/models/album_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe Album, type: :model do
 
     expect(price).to eq("2.00")
   end
+
+  it "knows if its expired based on expiry date" do
+    album = FactoryGirl.create(:album)
+
+    expect(album.expired?).to eq(false)
+
+    album.update(expiry_date: "#{Time.now - 1.month}")
+
+    expect(album.expired?).to eq(true)
+  end
 end


### PR DESCRIPTION
Albums now have expiry dates. If an album is past is expiration date, the
album's show page will not show 'add to cart' but rather will show 'no longer
available'.

Albums have a default expiry date value of September 9, 2016.

Albums have 'expired?' method that returns true/false value.

The orders routes were changed from singular to plural; the custom orders/index
action was simply added to that resource.

closes #125 

@Draganovic @julsfelic @Salvi6God 
