### PR TITLE
Expired albums do not appear on indicies for user #152

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,7 +1,7 @@
 class AlbumsController < ApplicationController
   def index
     @genres = Genre.all
-    @albums = Album.all
+    @albums = Album.unexpired_albums
     @featured_album = Album.take
   end
 

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -5,5 +5,6 @@ class ArtistsController < ApplicationController
 
   def show
     @artist = Artist.find_by(slug: params[:artist_name])
+    @albums = @artist.albums.unexpired_albums
   end
 end

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -1,6 +1,7 @@
 class GenresController < ApplicationController
   def show
     @genre = Genre.find_by(slug: params[:genre])
+    @albums = @genre.albums.unexpired_albums
     render file: "public/404" if @genre.nil?
   end
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -19,6 +19,10 @@ class Album < ActiveRecord::Base
     limit(count).order("RANDOM()")
   end
 
+  def self.unexpired_albums
+    all.reject { |album| album.expired? }
+  end
+
   def to_param
     slug
   end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -20,7 +20,7 @@ class Album < ActiveRecord::Base
   end
 
   def self.unexpired_albums
-    all.reject { |album| album.expired? }
+    all.reject(&:expired?)
   end
 
   def to_param

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -5,7 +5,7 @@
 <div class="container section-container">
   <section class="clearfix">
     <h2>Albums</h2>
-    <% @artist.albums.each do |album| %>
+    <% @albums.each do |album| %>
       <div class="preview">
         <%= link_to image_tag(album.image_url), album %>
         <h3 class="album-title"> <%= link_to album.title, album %> </h3>

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -2,7 +2,7 @@
   <h2><%= @genre.name %></h2>
 
   <section class="clearfix">
-    <% @genre.albums.each do |album| %>
+    <% @albums.each do |album| %>
       <div class="preview">
         <%= link_to(image_tag(album.image_url), album) %>
         <h3 class="album-title"><%= link_to(album.title, album) %></h3>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -35,7 +35,6 @@
     <%= hidden_field_tag "stripeToken" %>
     <%= hidden_field_tag "stripeEmail" %>
     <%= hidden_field_tag "stripeAmount" %>
-    <%#= button_to "Confirm Order", order_path(@order, :order => {user_id: current_user.id, total: @order.get_total}), { id: "checkout" } %>
     <%= button_to "Confirm Order", @order, { id: "checkout" } %>
   <% end %>
 

--- a/spec/features/user_can_view_an_artist_page_spec.rb
+++ b/spec/features/user_can_view_an_artist_page_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "User can view an artist page" do
   scenario "they see all albums associated with artist" do
+    genre = Genre.create(name: "Jazz", slug: "jazz")
     artist = Artist.create(name: "Miles Davis", slug: "miles-davis")
     album_1 = artist.albums.create(
       title: "Bitches Brew",
@@ -10,7 +11,8 @@ RSpec.feature "User can view an artist page" do
       release_year: 1970,
       price: 1500,
       slug: "bitches-brew",
-      expiry_date: Time.now
+      genre_id: genre.id,
+      expiry_date: (Time.now + 6.months)
     )
     album_2 = artist.albums.create(
       title: "Kind of Blue",
@@ -19,7 +21,8 @@ RSpec.feature "User can view an artist page" do
       release_year: 1959,
       price: 1700,
       slug: "kind-of-blue",
-      expiry_date: Time.now
+      genre_id: genre.id,
+      expiry_date: (Time.now + 6.months)
     )
 
     visit albums_path

--- a/spec/features/user_can_view_an_artist_page_spec.rb
+++ b/spec/features/user_can_view_an_artist_page_spec.rb
@@ -9,7 +9,8 @@ RSpec.feature "User can view an artist page" do
       image_url: "https://upload.wikimedia.org/wikipedia/en/thumb/7/72/Bitches_brew.jpg/220px-Bitches_brew.jpg",
       release_year: 1970,
       price: 1500,
-      slug: "bitches-brew"
+      slug: "bitches-brew",
+      expiry_date: Time.now
     )
     album_2 = artist.albums.create(
       title: "Kind of Blue",
@@ -17,7 +18,8 @@ RSpec.feature "User can view an artist page" do
       image_url: "https://upload.wikimedia.org/wikipedia/en/9/9c/MilesDavisKindofBlue.jpg",
       release_year: 1959,
       price: 1700,
-      slug: "kind-of-blue"
+      slug: "kind-of-blue",
+      expiry_date: Time.now
     )
 
     visit albums_path

--- a/spec/features/user_cannot_see_expired_albums_on_indices_spec.rb
+++ b/spec/features/user_cannot_see_expired_albums_on_indices_spec.rb
@@ -20,4 +20,25 @@ RSpec.feature "User cannot see expired albums on indicies" do
       expect(page).to_not have_content("Add to cart")
     end
   end
+
+  scenario "the expired album does not appear on genre albums index" do
+    album = FactoryGirl.create(:album)
+    genre = FactoryGirl.create(:genre)
+    album.update(expiry_date: (Time.now - 7.months), genre_id: genre.id)
+
+    user = User.create(username: "scottrick",
+                       password: "password",
+                       email: "email@email.com"
+                      )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit genre_path(album.genre)
+
+    within(".section-container") do
+      expect(page).to_not have_content(album.title)
+      expect(page).to_not have_content(album.artist.name)
+      expect(page).to_not have_content("Add to cart")
+    end
+  end
 end

--- a/spec/features/user_cannot_see_expired_albums_on_indices_spec.rb
+++ b/spec/features/user_cannot_see_expired_albums_on_indices_spec.rb
@@ -41,4 +41,25 @@ RSpec.feature "User cannot see expired albums on indicies" do
       expect(page).to_not have_content("Add to cart")
     end
   end
+
+  scenario "expired albums do not appear on the artist page" do
+    album = FactoryGirl.create(:album)
+    genre = FactoryGirl.create(:genre)
+    user = User.create(username: "scottrick",
+                       password: "password",
+                       email: "email@email.com"
+                      )
+
+    album.update(expiry_date: (Time.now - 7.months), genre_id: genre.id)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit artist_path(album.artist)
+
+    within(".section-container") do
+      expect(page).to_not have_content(album.title)
+      expect(page).to_not have_content(album.artist.name)
+      expect(page).to_not have_content("Add to cart")
+    end
+  end
 end

--- a/spec/features/user_cannot_see_expired_albums_on_indices_spec.rb
+++ b/spec/features/user_cannot_see_expired_albums_on_indices_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "User cannot see expired albums on indicies" do
+  scenario "the expired album does not appear on albums index" do
+    album = FactoryGirl.create(:album)
+    album.update(expiry_date: (Time.now - 7.months))
+
+    user = User.create(username: "scottrick",
+                       password: "password",
+                       email: "email@email.com"
+                      )
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit albums_path
+
+    within(".section-container .clearfix") do
+      expect(page).to_not have_content(album.title)
+      expect(page).to_not have_content(album.artist.name)
+      expect(page).to_not have_content("Add to cart")
+    end
+  end
+end


### PR DESCRIPTION
This merge adds three pieces related to not seeing expired albums:
-the main albums index
-the artist show page
-the genre show page

Expired albums will be hidden from those pages. See the commits for more details.
closes #152 
@julsfelic @Salvi6God @Draganovic @ksk5280 
