### PR TITLE
Fixes tests that were affected by switch to button

### DIFF
--- a/spec/features/guest_can_checkout_spec.rb
+++ b/spec/features/guest_can_checkout_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Guest can checkout" do
 
     visit carts_path
 
-    click_link "Checkout"
+    click_button "Checkout"
 
     expect(current_path).to eq(login_path)
 
@@ -24,7 +24,7 @@ RSpec.feature "Guest can checkout" do
 
     visit carts_path
 
-    click_link "Checkout"
+    click_button "Checkout"
     expect(current_path).to eq(new_order_path)
 
     expect(page).to have_content("Confirm Your Order")
@@ -56,7 +56,7 @@ RSpec.feature "Guest can checkout" do
 
     visit carts_path
 
-    click_link "Checkout"
+    click_button "Checkout"
 
     click_button "Confirm Order"
 

--- a/spec/features/guest_can_view_past_orders_spec.rb
+++ b/spec/features/guest_can_view_past_orders_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Existing user can view past orders" do
     end
 
     visit carts_path
-    click_link "Checkout"
+    click_button "Checkout"
     click_button "Confirm Order"
 
     visit albums_path
@@ -27,7 +27,7 @@ RSpec.feature "Existing user can view past orders" do
     end
 
     visit carts_path
-    click_link "Checkout"
+    click_button "Checkout"
     click_button "Confirm Order"
 
     visit dashboard_path

--- a/spec/features/user_can_view_specific_past_orders_spec.rb
+++ b/spec/features/user_can_view_specific_past_orders_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Existing user can view past orders" do
     end
 
     visit carts_path
-    click_link "Checkout"
+    click_button "Checkout"
     click_button "Confirm Order"
 
     visit dashboard_path


### PR DESCRIPTION
When I made the switch for a link to a button for the checkout button
I forgot to change the tests to reflect this.

Closes #160 

@scottfirestone @Draganovic @Salvi6God 
