### PR TITLE
Add album status to admin album index

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -593,3 +593,9 @@ h2 {
 .admin-albums a:hover {
   text-decoration: underline;
 }
+
+#album_expiry_date_1i,
+#album_expiry_date_2i,
+#album_expiry_date_3i {
+  width: 21%;
+}

--- a/app/controllers/admin/albums_controller.rb
+++ b/app/controllers/admin/albums_controller.rb
@@ -46,6 +46,6 @@ class Admin::AlbumsController < Admin::BaseController
   private
 
   def album_params
-    params.require(:album).permit(:title, :slug, :artist_id, :genre_id, :description, :image_url, :release_year, :price)
+    params.require(:album).permit(:title, :slug, :artist_id, :genre_id, :description, :image_url, :release_year, :price, :expiry_date)
   end
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -34,4 +34,12 @@ class Album < ActiveRecord::Base
   def expired?
     Time.now > expiry_date
   end
+
+  def status
+    if expired?
+      "Expired"
+    else
+      "Valid"
+    end
+  end
 end

--- a/app/views/admin/albums/_form.html.erb
+++ b/app/views/admin/albums/_form.html.erb
@@ -24,7 +24,7 @@
   <%= f.text_field :price %>
 
   <%= f.label :expiry_date %>
-  <%= f.date_select :expiry_date %> %>
+  <%= f.date_select :expiry_date %>
 
   <%= f.submit submit_name %>
 <% end %>

--- a/app/views/admin/albums/_form.html.erb
+++ b/app/views/admin/albums/_form.html.erb
@@ -23,5 +23,8 @@
   <%= f.label :price %>
   <%= f.text_field :price %>
 
+  <%= f.label :expiry_date %>
+  <%= f.date_select :expiry_date %> %>
+
   <%= f.submit submit_name %>
 <% end %>

--- a/app/views/admin/albums/index.html.erb
+++ b/app/views/admin/albums/index.html.erb
@@ -8,6 +8,7 @@
         <th>Title</th>
         <th>Description</th>
         <th>Artist</th>
+        <th>Status</th>
         <th>Edit</th>
       </tr>
     </thead>
@@ -18,6 +19,7 @@
           <td><%= link_to album.title, album_path(album) %></td>
           <td><%= album.description %></td>
           <td><%= link_to album.artist.name, album.artist %></td>
+          <td><%= album.status %></td>
           <td><%= link_to "Edit", edit_admin_album_path(album) %></td>
         </tr>
       <% end %>

--- a/spec/features/admin_can_view_albums_spec.rb
+++ b/spec/features/admin_can_view_albums_spec.rb
@@ -12,6 +12,10 @@ RSpec.feature "Admin can view albums" do
       FactoryGirl.create(:album)
     end
 
+    expired_album = FactoryGirl.create(:album)
+
+    expired_album.update(expiry_date: (Time.now - 7.months))
+
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit admin_dashboard_path
@@ -26,7 +30,16 @@ RSpec.feature "Admin can view albums" do
       expect(page).to have_content(album.description)
       expect(page).to have_content(album.title)
       expect(page).to have_content(album.artist.name)
+      expect(page).to have_content(album.status)
       expect(page).to have_link("Edit", edit_admin_album_path(album))
     end
+
+    expect(page).to have_css("img[src*='#{expired_album.image_url}']")
+    expect(page).to have_link(expired_album.title.to_s, album_path(expired_album))
+    expect(page).to have_content(expired_album.description)
+    expect(page).to have_content(expired_album.title)
+    expect(page).to have_content(expired_album.artist.name)
+    expect(page).to have_content(expired_album.status)
+    expect(page).to have_link("Edit", edit_admin_album_path(expired_album))
   end
 end

--- a/spec/models/album_spec.rb
+++ b/spec/models/album_spec.rb
@@ -27,4 +27,14 @@ RSpec.describe Album, type: :model do
 
     expect(album.expired?).to eq(true)
   end
+
+  it "knows its status based on expiration date" do
+    album = FactoryGirl.create(:album)
+
+    expect(album.status).to eq("Valid")
+
+    album.update(expiry_date: "#{Time.now - 1.month}")
+
+    expect(album.status).to eq("Expired")
+  end
 end


### PR DESCRIPTION
Admin album table now has a status column showing whether or not the album
is expired. Added a method to print a string based on the expiration status,
which appears in the aforementioned table.

closes #166 

@julsfelic @Draganovic @Salvi6God 
