### PR TITLE
Remove password field from admin edit info form.

### DIFF
--- a/app/views/admin/infos/edit.html.erb
+++ b/app/views/admin/infos/edit.html.erb
@@ -8,9 +8,6 @@
     <%= f.label :email %>
     <%= f.email_field :email %>
 
-    <%= f.label :password %>
-    <%= f.password_field :password %>
-
     <%= f.submit "Update Account" %>
   <% end %>
 </section>

--- a/spec/features/admin_can_modify_admin_data_spec.rb
+++ b/spec/features/admin_can_modify_admin_data_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature "Admin can modify admin info" do
     expect(page).to have_selector("input[value='#{admin.email}']")
 
     fill_in "Username", with: "New Username"
-    fill_in "Password", with: "new_password"
     fill_in "Email",    with: "new_email@example.com"
 
     click_on "Update Account"


### PR DESCRIPTION
A design decision was made to disallow an admin from editing their password
on the app; we prefer this ability to stay in the console. The fields were
removed from the applicable form.

closes #110 

@julsfelic @Draganovic @Salvi6God 
